### PR TITLE
Added multiple cycle upload argument

### DIFF
--- a/pyseed/seed_client.py
+++ b/pyseed/seed_client.py
@@ -1021,12 +1021,13 @@ class SeedClient(SeedClientWrapper):
     def save_meter_data(self, property_id: int, meter_id: int, meter_data) -> dict:
         pass
 
-    def start_save_data(self, import_file_id: int, multiple_cycle_upload: bool) -> dict:
+    def start_save_data(self, import_file_id: int, multiple_cycle_upload: bool = False) -> dict:
         """start the background process to save the data file to the database.
         This is the state before the mapping.
 
         Args:
             import_file_id (int): id of the import file to save
+            multiple_cycle_upload (bool): whether to use multiple cycle upload
 
         Returns:
             dict: progress key
@@ -1190,6 +1191,7 @@ class SeedClient(SeedClientWrapper):
             column_mapping_profile_name (str): Name of the column mapping profile to use
             column_mappings_file (str): Mapping that will be uploaded to the column_mapping_profile_name
             import_meters_if_exist (bool): If true, will import meters from the meter tab if they exist in the datafile. Defaults to False.
+            multiple_cycle_upload (bool): Whether to use multiple cycle upload. Defaults to False.
 
         Returns:
             dict: {

--- a/pyseed/seed_client.py
+++ b/pyseed/seed_client.py
@@ -1021,7 +1021,7 @@ class SeedClient(SeedClientWrapper):
     def save_meter_data(self, property_id: int, meter_id: int, meter_data) -> dict:
         pass
 
-    def start_save_data(self, import_file_id: int) -> dict:
+    def start_save_data(self, import_file_id: int, multiple_cycle_upload: bool) -> dict:
         """start the background process to save the data file to the database.
         This is the state before the mapping.
 
@@ -1039,7 +1039,8 @@ class SeedClient(SeedClientWrapper):
         return self.client.post(
             "import_files_start_save_data_pk",
             url_args={"PK": import_file_id},
-            json={"cycle_id": self.cycle_id},
+            json={"cycle_id": self.cycle_id,
+                  "multiple_cycle_upload": multiple_cycle_upload},
         )
 
     def start_map_data(self, import_file_id: int) -> dict:
@@ -1177,6 +1178,7 @@ class SeedClient(SeedClientWrapper):
         column_mapping_profile_name: str,
         column_mappings_file: str,
         import_meters_if_exist: bool = False,
+        multiple_cycle_upload: bool = False,
         **kwargs,
     ) -> dict:
         """Upload a file to the cycle_id that is defined in the constructor. This carries the
@@ -1200,7 +1202,7 @@ class SeedClient(SeedClientWrapper):
         import_file_id = result["import_file_id"]
 
         # start processing
-        result = self.start_save_data(import_file_id)
+        result = self.start_save_data(import_file_id, multiple_cycle_upload)
         progress_key = result.get("progress_key", None)
 
         # wait until upload is complete

--- a/pyseed/seed_client.py
+++ b/pyseed/seed_client.py
@@ -1203,7 +1203,6 @@ class SeedClient(SeedClientWrapper):
         import_file_id = result["import_file_id"]
         multiple_cycle_upload = kwargs.pop("multiple_cycle_upload", False)
 
-
         # start processing
         result = self.start_save_data(import_file_id, multiple_cycle_upload)
         progress_key = result.get("progress_key", None)

--- a/pyseed/seed_client.py
+++ b/pyseed/seed_client.py
@@ -1179,7 +1179,6 @@ class SeedClient(SeedClientWrapper):
         column_mapping_profile_name: str,
         column_mappings_file: str,
         import_meters_if_exist: bool = False,
-        multiple_cycle_upload: bool = False,
         **kwargs,
     ) -> dict:
         """Upload a file to the cycle_id that is defined in the constructor. This carries the
@@ -1202,6 +1201,8 @@ class SeedClient(SeedClientWrapper):
         dataset = self.get_or_create_dataset(dataset_name)
         result = self.upload_datafile(dataset["id"], datafile, datafile_type)
         import_file_id = result["import_file_id"]
+        multiple_cycle_upload = kwargs.pop("multiple_cycle_upload", False)
+
 
         # start processing
         result = self.start_save_data(import_file_id, multiple_cycle_upload)


### PR DESCRIPTION
Added an optional boolean argument to the seed_client.upload_and_match_datafile function. You can use the attached sample jupyter notebook to test it. The data file comes from seed repo in folder "seed/tests/data" and is called "Sample_MultipleCycles.xlsx". I've also attached the mapping profile file.

[upload_example_data.ipynb.zip](https://github.com/SEED-platform/py-seed/files/12252250/upload_example_data.ipynb.zip)


[Multiple Cycle_mapping_profile.csv](https://github.com/SEED-platform/py-seed/files/12252246/Multiple.Cycle_mapping_profile.csv)
