### PR TITLE
Increase timeout for server start

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           # migration take ~6 minutes to run along.
           url: "http://localhost:8000/"
           responseCode: 200
-          timeout: 480000
+          timeout: 640000
           interval: 5000
       - name: Wait another 30s
         uses: jakejarvis/wait-action@master


### PR DESCRIPTION
The latest version of SEED has a long-running migration that has to happen in the test environment. This extends the timeout significantly to cover it.