### PR TITLE
Endpoint to download an Audit Template Report Submission and store in SEED

### DIFF
--- a/pyseed/seed_client.py
+++ b/pyseed/seed_client.py
@@ -1418,6 +1418,58 @@ class SeedClient(SeedClientWrapper):
 
         return response
 
+    def retrieve_at_submission_and_update(self, audit_template_submission_id: int, cycle_id: int, seed_id: int, report_format: str = 'pdf') -> dict:
+        """Connect to audit template and retrieve audit report by submission ID
+
+        Args:
+            audit_template_submission_id (int): ID of the AT submission report (different than building ID)
+            cycle_id (int): Cycle ID in SEED
+            seed_id (int): PropertyView ID in SEED
+            file_format (str): pdf or xml report, defaults to pdf
+
+        Returns:
+            dict: Response from the SEED API
+        """
+
+        # api/v3/audit_template/pk/get_submission
+        # accepts pdf or xml
+        response = self.client.get(
+            None,
+            required_pk=False,
+            endpoint="audit_template_submission",
+            url_args={"PK": audit_template_submission_id},
+            report_format=report_format
+        )
+
+        if response['status'] == 'success':
+
+            if report_format.lower() == 'pdf':
+                pdf_file = response['content']
+                response['pdf_report'] = pdf_file
+            else:
+                # assume XML
+                response['xml_report'] = response['content']
+
+            # TODO: add to inventory documents in SEED
+            # now post to api/v3/properties/PK/update_with_buildingsync
+            # xml_file = response['content']
+            # filename = 'at_' + str(int(time.time() * 1000)) + '.xml'
+            # files = [
+            #     ('file', (filename, xml_file)),
+            #     ('file_type', (None, 1))
+            # ]
+
+            # response = self.client.put(
+            #     None,
+            #     required_pk=False,
+            #     endpoint="properties_update_with_buildingsync",
+            #     url_args={"PK": seed_id},
+            #     files=files,
+            #     cycle_id=cycle_id
+            # )
+
+        return response
+
     def retrieve_portfolio_manager_property(self, username: str, password: str, pm_property_id: int, save_file_name: Path) -> dict:
         """Connect to portfolio manager and download an individual properties data in Excel format
 

--- a/pyseed/seed_client.py
+++ b/pyseed/seed_client.py
@@ -1418,17 +1418,19 @@ class SeedClient(SeedClientWrapper):
 
         return response
 
-    def retrieve_at_submission_and_update(self, audit_template_submission_id: int, cycle_id: int, seed_id: int, report_format: str = 'pdf') -> dict:
+    def retrieve_at_submission_and_update(self, audit_template_submission_id: int, cycle_id: int, seed_id: int, report_format: str = 'pdf', filename: str = None) -> dict:
         """Connect to audit template and retrieve audit report by submission ID
 
         Args:
             audit_template_submission_id (int): ID of the AT submission report (different than building ID)
-            cycle_id (int): Cycle ID in SEED
+            cycle_id (int): Cycle ID in SEED (needed for XML but not actually for PDF)
             seed_id (int): PropertyView ID in SEED
             file_format (str): pdf or xml report, defaults to pdf
+            filename (str): filename to use to upload to SEED
 
         Returns:
             dict: Response from the SEED API
+            including the PDF file (if that format was requested)
         """
 
         # api/v3/audit_template/pk/get_submission
@@ -1442,33 +1444,44 @@ class SeedClient(SeedClientWrapper):
         )
 
         if response['status'] == 'success':
-
             if report_format.lower() == 'pdf':
                 pdf_file = response['content']
-                response['pdf_report'] = pdf_file
+                if not filename:
+                    filename = 'at_submission_report_' + str(audit_template_submission_id) + '.pdf'
+                files = [
+                    ('file', (filename, pdf_file)),
+                    ('file_type', (None, 1))
+                ]
+                response2 = self.client.put(
+                    None,
+                    required_pk=False,
+                    endpoint="properties_upload_inventory_document",
+                    url_args={"PK": seed_id},
+                    files=files
+                )
+                response2['pdf_report'] = pdf_file
             else:
                 # assume XML
-                response['xml_report'] = response['content']
+                # now post to api/v3/properties/PK/update_with_buildingsync
+                xml_file = response['content']
+                if not filename:
+                    filename = 'at_' + str(int(time.time() * 1000)) + '.xml'
 
-            # TODO: add to inventory documents in SEED
-            # now post to api/v3/properties/PK/update_with_buildingsync
-            # xml_file = response['content']
-            # filename = 'at_' + str(int(time.time() * 1000)) + '.xml'
-            # files = [
-            #     ('file', (filename, xml_file)),
-            #     ('file_type', (None, 1))
-            # ]
+                files = [
+                    ('file', (filename, xml_file)),
+                    ('file_type', (None, 1))
+                ]
 
-            # response = self.client.put(
-            #     None,
-            #     required_pk=False,
-            #     endpoint="properties_update_with_buildingsync",
-            #     url_args={"PK": seed_id},
-            #     files=files,
-            #     cycle_id=cycle_id
-            # )
+                response2 = self.client.put(
+                    None,
+                    required_pk=False,
+                    endpoint="properties_update_with_buildingsync",
+                    url_args={"PK": seed_id},
+                    files=files,
+                    cycle_id=cycle_id
+                )
 
-        return response
+        return response2
 
     def retrieve_portfolio_manager_property(self, username: str, password: str, pm_property_id: int, save_file_name: Path) -> dict:
         """Connect to portfolio manager and download an individual properties data in Excel format

--- a/pyseed/seed_client_base.py
+++ b/pyseed/seed_client_base.py
@@ -74,6 +74,7 @@ URLS = {
         'properties_meters': '/api/v3/properties/PK/meters/',
         'properties_meter_usage': '/api/v3/properties/PK/meter_usage/',
         'audit_template_building_xml': '/api/v3/audit_template/PK/get_building_xml',
+        'audit_template_submission': '/api/v3/audit_template/PK/get_submission',
         # GET & POST with replaceable keys
         'properties_meters_reading': '/api/v3/properties/PK/meters/METER_PK/readings/',
     }
@@ -215,6 +216,9 @@ class SEEDBaseClient(JSONAPI):
             error = False
         elif 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' in response_content_types:
             # spreadsheet response
+            error = False
+        elif 'application/pdf' in response_content_types:
+            # PDF report response
             error = False
         elif 'application/json' not in response_content_types:
             # get as text

--- a/pyseed/seed_client_base.py
+++ b/pyseed/seed_client_base.py
@@ -68,6 +68,7 @@ URLS = {
         # PUTs with replaceable keys:
         'properties_update_with_buildingsync': 'api/v3/properties/PK/update_with_building_sync/',
         'property_update_with_espm': 'api/v3/properties/PK/update_with_espm/',
+        'properties_upload_inventory_document': 'api/v3/properties/PK/upload_inventory_document',
         # GETs with replaceable keys
         'import_files_matching_results': '/api/v3/import_files/PK/matching_and_geocoding_results/',
         'progress': '/api/v3/progress/PROGRESS_KEY/',
@@ -481,6 +482,7 @@ class UpdateMixin(object):
         data_name = _set_default(self, 'data_name', data_name, required=False)
         url = add_pk(self.urls[endpoint], pk, required=kwargs.pop('required_pk', True), slash=True)
         url = _replace_url_args(url, url_args)
+
         response = super(UpdateMixin, self)._put(url=url, **kwargs)
         self._check_response(response, **kwargs)
         return self._get_result(response, data_name=data_name, **kwargs)


### PR DESCRIPTION
This functionality will all users to specify an audit template report submission to download, in either PDF or XML format.

- If xml is specified, the existing "update_with_buildingsync" method will be used to update the property.  
- If pdf is specified, the retrieved PDF document will be added to SEED as an "inventory document" on the property and the content of the returned to the user (to enable easy saving locally)