### PR TITLE
Add is_omitted column to column mapping profiles

### DIFF
--- a/pyseed/seed_client.py
+++ b/pyseed/seed_client.py
@@ -924,6 +924,7 @@ class SeedClient(SeedClientWrapper):
                         "from_units": null,
                         "to_table_name": "PropertyState"
                         "to_field": "address_line_1",
+                        "isOmitted": False
                     },
                     {
                         "from_field": "address1",
@@ -934,6 +935,7 @@ class SeedClient(SeedClientWrapper):
                     ...
                 ]
 
+            The isOmitted mapping may be absent - it is treated as False if it is not present.
         Returns:
             dict: {
                 'id': 1
@@ -972,9 +974,9 @@ class SeedClient(SeedClientWrapper):
     ) -> dict:
         """creates or updates a mapping profile. The format of the mapping file is a CSV with the following format:
 
-            Raw Columns,    units, SEED Table,    SEED Columns\n
-            PM Property ID,      , PropertyState, pm_property_id\n
-            Building ID,         , PropertyState, custom_id_1\n
+            Raw Columns,    units, SEED Table,    SEED Columns, Omit\n
+            PM Property ID,      , PropertyState, pm_property_id, False\n
+            Building ID,         , PropertyState, custom_id_1, False\n
             ...\n
 
         This only works for 'Normal' column mapping profiles, that is, it does not work for

--- a/pyseed/seed_client.py
+++ b/pyseed/seed_client.py
@@ -924,7 +924,7 @@ class SeedClient(SeedClientWrapper):
                         "from_units": null,
                         "to_table_name": "PropertyState"
                         "to_field": "address_line_1",
-                        "isOmitted": False
+                        "is_omitted": False
                     },
                     {
                         "from_field": "address1",
@@ -935,7 +935,7 @@ class SeedClient(SeedClientWrapper):
                     ...
                 ]
 
-            The isOmitted mapping may be absent - it is treated as False if it is not present.
+            The is_omitted mapping may be absent - it is treated as False if it is not present.
         Returns:
             dict: {
                 'id': 1

--- a/pyseed/utils.py
+++ b/pyseed/utils.py
@@ -121,9 +121,9 @@ def read_map_file(mapfile_path):
                     "to_field": rowitem[3],
                 }
         try:
-            data["isOmitted"] = True if rowitem[4].lower().strip() == "true" else False
+            data["is_omitted"] = True if rowitem[4].lower().strip() == "true" else False
         except IndexError:
-            data["isOmitted"] = False
+            data["is_omitted"] = False
 
         maplist.append(data)
 

--- a/pyseed/utils.py
+++ b/pyseed/utils.py
@@ -113,15 +113,18 @@ def read_map_file(mapfile_path):
 
     # Open the mapping file and fill list
     maplist = list()
-
     for rowitem in map_reader:
-        maplist.append(
-            {
-                'from_field': rowitem[0],
-                'from_units': rowitem[1],
-                'to_table_name': rowitem[2],
-                'to_field': rowitem[3],
-            }
-        )
+        data = {
+                    "from_field": rowitem[0],
+                    "from_units": rowitem[1],
+                    "to_table_name": rowitem[2],
+                    "to_field": rowitem[3],
+                }
+        try:
+            data["isOmitted"] = True if rowitem[4].lower().strip() == "true" else False
+        except IndexError:
+            data["isOmitted"] = False
+
+        maplist.append(data)
 
     return maplist

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,6 +22,6 @@ class UtilsTest(unittest.TestCase):
             "from_units": "ft**2",
             "to_field": "gross_floor_area",
             "to_table_name": "PropertyState",
-            "isOmitted": False
+            "is_omitted": False
         }
         assert mappings[5] == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,5 +22,6 @@ class UtilsTest(unittest.TestCase):
             "from_units": "ft**2",
             "to_field": "gross_floor_area",
             "to_table_name": "PropertyState",
+            "isOmitted": False
         }
         assert mappings[5] == expected


### PR DESCRIPTION
Allows a user to mark a column for omission in a column mapping profile updated or created in the py-seed client.

Needs to be deployed in concert with https://github.com/SEED-platform/seed/pull/4740