### PR TITLE
Fix "TaxlotState" -> "TaxLotState"

### DIFF
--- a/pyseed/seed_client.py
+++ b/pyseed/seed_client.py
@@ -1035,7 +1035,7 @@ class SeedClient(SeedClientWrapper):
             payload = {
                 "column_name": column_name,
                 "display_name": display_name,
-                "table_name": "PropertyState" if inventory_type == "Property" else "TaxlotState",
+                "table_name": "PropertyState" if inventory_type == "Property" else "TaxLotState",
                 "column_description": column_description,
                 "data_type": data_type,
                 "organization_id": self.get_org_id(),


### PR DESCRIPTION
The casing for `TaxLotState` is incorrect. When a client tries to configure SEED columns using py-seed, it fails because it doesn't recognize `TaxlotState`. Here is what SEED returns when you try to run the current code:

```
table_name must be "PropertyState" or "TaxLotState", 
calling service SEED as SEEDReadWriteClient.post with url http://127.0.0.1:80/api/v3/columns/?organization_id=2, 
http method: POST supplied with json={
   'column_name': 'water_heating_first_hour_rating', 
   'display_name': ' Water Heating First Hour Rating', 
   'table_name': 'TaxlotState', 
   'column_description': ' Water Heating First Hour Rating', 
   'data_type': ' number', 
   'organization_id': 2
}, organization_id=2 http status code: 400
```