### PR TITLE
Prevent unnecessary port addition to URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.tool-versions
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/pyseed/seed_client_base.py
+++ b/pyseed/seed_client_base.py
@@ -192,7 +192,7 @@ class SEEDBaseClient(JSONAPI):
             self.base_url = base_url if base_url else "localhost"
         if not getattr(self, "port", None):
             self.port = port if port else None
-        if self.port:
+        if self.port and not self.base_url.startswith("http"):
             self.base_url = f"{self.base_url}:{self.port}"
         if not self.base_url.endswith("/"):
             self.base_url = self.base_url + "/"


### PR DESCRIPTION
Ensure the port is only added to the base URL when the base URL does not already start with "http".