### PR TITLE
Add cross cycles inventory,  column profiles, delete inventory, and show only populated columns

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=50000"]
@@ -25,7 +25,7 @@ repos:
       - id: prettier
         types_or: [css, yaml, markdown, html, scss, javascript, json]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.8
+    rev: v0.11.2
     hooks:
       # Run the linter
       - id: ruff

--- a/pyseed/apibase.py
+++ b/pyseed/apibase.py
@@ -16,7 +16,7 @@ def add_pk(url, pk, required=True, slash=False):
     if required and not pk:
         raise APIClientError("id/pk must be supplied")
     if pk:
-        if isinstance(pk, str) and not pk.isdigit() or (not isinstance(pk, (int, str)) or int(pk) < 0):
+        if (isinstance(pk, str) and not pk.isdigit()) or (not isinstance(pk, (int, str)) or int(pk) < 0):
             raise TypeError("id/pk must be a positive integer")
         url = f"{url}/{pk}" if not url.endswith("/") else f"{url}{pk}"
     # Only add the trailing slash if it's not already there

--- a/pyseed/seed_client.py
+++ b/pyseed/seed_client.py
@@ -412,7 +412,7 @@ class SeedClient(SeedClientWrapper):
                     return profile
 
         # if here, then we will need to create a new column list profile
-        payload = {}
+        payload: dict[str, Any] = {}
         payload["name"] = name
         payload["inventory_type"] = inventory_type
         payload["profile_location"] = profile_location
@@ -420,7 +420,7 @@ class SeedClient(SeedClientWrapper):
             # get the default columns
             seed_columns = self.get_columns()
             # grab only the columns that are on the PropertyState and named pm_property_id, address_line_1, and on the TaxLotState named jurisdiction_tax_lot_id
-            column_list = []
+            column_list: list[dict] = []
             for add_column in seed_columns["columns"]:
                 # This should be extended as needed. Not sure how to find the best default columns, other than just running the 'trigger_show_only_populated' method
                 if add_column["table_name"] == "PropertyState" and add_column["column_name"] in ["pm_property_id", "address_line_1"]:

--- a/pyseed/seed_client.py
+++ b/pyseed/seed_client.py
@@ -34,7 +34,7 @@ class SeedClientWrapper:
         """wrapper around SEEDReadWriteClient.
 
         Args:
-            organization_id (int): _description_
+            organization_id (int): SEED organization ID
             connection_params (dict, optional): parameters to connect to SEED. Defaults to None. If using, then must contain the following:
                 {
                     "name": "not used - can be any string",
@@ -334,8 +334,8 @@ class SeedClient(SeedClientWrapper):
         """Return the list of column list profiles that are available for the organization
 
         Args:
-            inventory_type (str, optional): _description_. Defaults to None.
-            profile_location (str, optional): _description_. Defaults to None.
+            inventory_type (str, optional): Property or Tax Lot. Defaults to "Property".
+            profile_location (str, optional): Detail View Profile or List View Profile. Defaults to "List View Profile".
 
         Returns:
             dict: {
@@ -626,7 +626,7 @@ class SeedClient(SeedClientWrapper):
             label_name (str): Name of the label to delete.
 
         Returns:
-            dict: _description_
+            dict: info on the deleted label
         """
         label = self.get_labels(filter_by_name=[label_name])
         if len(label) != 1:
@@ -1163,8 +1163,8 @@ class SeedClient(SeedClientWrapper):
         an already existing profile if it is there.
 
         Args:
-            mapping_profile_name (str): _description_
-            mapping_file (str): _description_
+            mapping_profile_name (str): Name of the mapping profile that will be created or updated.
+            mapping_file (str): Path to the mapping file will be used to create the mapping profile.
 
         Returns:
             dict: {

--- a/pyseed/seed_client.py
+++ b/pyseed/seed_client.py
@@ -202,11 +202,12 @@ class SeedClient(SeedClientWrapper):
 
         return None
 
-    def create_organization(self, org_name: str) -> dict:
+    def create_organization(self, org_name: str, allow_exist: bool = False) -> dict:
         """Create an organization with the given name
 
         Args:
             org_name (str): name of the organization to create
+            allow_exist (bool, optional): if True, then do not raise an exception if exists. Defaults to False.
 
         Returns:
             dict: {
@@ -236,7 +237,15 @@ class SeedClient(SeedClientWrapper):
         orgs = self.get_organizations()
         for org in orgs:
             if org["name"].lower() == org_name.lower():
-                raise Exception(f"Organization '{org_name}' already exists")
+                if allow_exist:
+                    # then match the response of the existing org
+                    return {
+                        "status": "success",
+                        "message": "Organization already exists",
+                        "organization": org,
+                    }
+                else:
+                    raise Exception(f"Organization '{org_name}' already exists")
 
         user_id = self.get_user_id(self.client.username)
 
@@ -304,12 +313,155 @@ class SeedClient(SeedClientWrapper):
         # NOTE: this seems to be the call that OEP uses (returns property and labels dictionaries)
         return self.client.get(property_view_id, endpoint="properties", data_name="properties")
 
+    def get_properties_by_cycles(self, column_list_profile_id: int, cycle_ids: list[int]) -> list:
+        """_summary_
+
+        Args:
+            column_list_profile_id (int): ID of the column list profile to use, which defines the columns to return
+            cycle_ids (list[int]): list of the cycle IDs to filter on
+
+        Returns:
+            list: list of dictionaries of each property, grouped by primary key (matching criteria)
+        """
+        payload = {"profile_id": column_list_profile_id, "cycle_ids": cycle_ids}
+        return self.client.post(endpoint="properties_filter_by_cycle", json=payload)
+
+    def get_column_list_profiles(self, inventory_type: Optional[str] = None, profile_location: Optional[str] = None) -> dict:
+        """Return the list of column list profiles that are available for the organization
+
+        Args:
+            inventory_type (str, optional): _description_. Defaults to None.
+            profile_location (str, optional): _description_. Defaults to None.
+
+        Returns:
+            dict: {
+                "status": "success",
+                "data": [
+                    {
+                    "id": 2,
+                    "name": "test",
+                    "profile_location": "List View Profile",
+                    "inventory_type": "Property",
+                    "columns": [
+                        {
+                        "id": 1367,
+                        "pinned": true,
+                        "order": 2,
+                        "column_name": "pm_property_id",
+                        "table_name": "PropertyState",
+                        }, ..
+                    ]
+                    },
+                    ...
+        """
+        payload = {}
+        if inventory_type:
+            payload["inventory_type"] = inventory_type
+        if profile_location:
+            payload["profile_location"] = profile_location
+
+        # do a check on the strings for inventory type and profile location, only if not none
+        if inventory_type and inventory_type not in ["Property", "Tax Lot"]:
+            raise ValueError("inventory_type must be either 'Property' or 'Tax Lot'")
+        if profile_location and profile_location not in ["List View Profile", "Detail View Profile"]:
+            raise ValueError("profile_location must be either 'List View Profile' or 'Detail View Profile")
+
+        # column_list_profiles/?brief=false&inventory_type=Property&organization_id=7&profile_location=List+View+Profile
+        return self.client.list(endpoint="column_list_profiles", **payload)
+
+    def get_or_create_column_list_profile(
+        self,
+        name: str,
+        inventory_type: str = "Property",
+        profile_location: str = "List View Profile",
+        columns: list = [],
+    ) -> dict:
+        """Create a column list profile with the given name and columns. This method will check if the name already exists, and if it does, will
+        return the existing column list profile. If creating a new one, then if the columns are empty, then a default set of columns will be used only.
+
+        Args:
+            name (str): Name of the column list profile to create
+            inventory_type (str, optional): Property or Tax Lot. Defaults to "Property".
+            profile_location (str, optional): Detail View Profile or List View Profile. Defaults to "List View Profile".
+            columns (dict, optional): dictionary of columns in the format below. Defaults to {}.
+
+
+        Returns: Either an existing or newly created column list profile
+            dict: {
+                'id': 2,
+                'name': 'test',
+                'profile_location': 'List View Profile',
+                'inventory_type': 'Property',
+                'columns': [
+                    {
+                    'id': 1367,
+                    'pinned': True,
+                    'order': 2,
+                    'column_name': 'pm_property_id',
+                    'table_name': 'PropertyState',
+                    }, ..
+                ]
+            }
+
+        """
+        # get the list of all column list profiles of inventory type and profile location
+        column_list_profiles = self.get_column_list_profiles(inventory_type=inventory_type, profile_location=profile_location)
+        if column_list_profiles != []:
+            for profile in column_list_profiles:
+                if profile["name"] == name:
+                    return profile
+
+        # if here, then we will need to create a new column list profile
+        payload = {}
+        payload["name"] = name
+        payload["inventory_type"] = inventory_type
+        payload["profile_location"] = profile_location
+        if columns == []:
+            # get the default columns
+            seed_columns = self.get_columns()
+            # grab only the columns that are on the PropertyState and named pm_property_id, address_line_1, and on the TaxLotState named jurisdiction_tax_lot_id
+            column_list = []
+            for add_column in seed_columns["columns"]:
+                # This should be extended as needed. Not sure how to find the best default columns, other than just running the 'trigger_show_only_populated' method
+                if add_column["table_name"] == "PropertyState" and add_column["column_name"] in ["pm_property_id", "address_line_1"]:
+                    # only add "id", "column_name", "order", "pinned", "table_name"
+                    to_add_column = {k: add_column[k] for k in ["id", "table_name", "column_name"]}
+                    to_add_column["pinned"] = False
+                    to_add_column["order"] = len(column_list) + 1
+                    column_list.append(to_add_column)
+                elif add_column["table_name"] == "TaxLotState" and add_column["column_name"] == "jurisdiction_tax_lot_id":
+                    to_add_column = {k: add_column[k] for k in ["id", "table_name", "column_name"]}
+                    to_add_column["pinned"] = False
+                    to_add_column["order"] = len(column_list) + 1
+                    column_list.append(to_add_column)
+
+            payload["columns"] = column_list
+        else:
+            payload["columns"] = columns
+        payload["derived_columns"] = []
+
+        return self.client.post(endpoint="column_list_profiles", json=payload)
+
+    # def trigger_show_only_populated(self, cycle_id: int, column_list_profile_name: str) -> dict:
+    #     """_summary_
+
+    #     Args:
+    #         cycle_id (int): _description_
+
+    #     Returns:
+    #         dict: _description_
+    #     """
+    #     # {"cycle_id": 13, "inventory_type": "Property"}
+    #     # column_list_profiles/1/show_populated/
+    #     return None
+
     def search_buildings(
         self,
         identifier_filter: Optional[str] = None,
         identifier_exact: Optional[str] = None,
         cycle_id: Optional[int] = None,
     ) -> dict:
+        # TODO: create an alias to also have this be search_properties
         if not cycle_id:
             cycle_id = self.cycle_id
         payload: dict[str, Any] = {
@@ -711,6 +863,30 @@ class SeedClient(SeedClientWrapper):
                 return cycle
 
         raise ValueError(f"cycle '{cycle_name}' not found")
+
+    def delete_inventory(self) -> dict:
+        """USE WITH CAUTION. This will delete all the inventory items in an organization.
+        The organization ID is what is set in the instantiated class.
+        USE WITH CAUTION.
+
+        Returns:
+            dict: {
+                    'status': 'success',
+                    'message': 'Inventory deleted'
+                }
+        """
+        result = self.client.delete(
+            None,
+            endpoint="delete_inventory",
+            required_pk=False,
+            url_args={"ORG_ID": self.client.org_id},
+        )
+        progress_key = result.get("progress_key", None)
+
+        # wait until delete is complete
+        result = self.track_progress_result(progress_key)
+
+        return result
 
     def delete_cycle(self, cycle_id: str) -> dict:
         """Delete the cycle. This will only work if there are no properties or tax lots in the cycle

--- a/pyseed/seed_client.py
+++ b/pyseed/seed_client.py
@@ -442,18 +442,56 @@ class SeedClient(SeedClientWrapper):
 
         return self.client.post(endpoint="column_list_profiles", json=payload)
 
-    # def trigger_show_only_populated(self, cycle_id: int, column_list_profile_name: str) -> dict:
-    #     """_summary_
+    def trigger_show_only_populated(
+        self,
+        cycle_id: int,
+        column_list_profile_name: str,
+        inventory_type: str = "Property",
+        profile_location: str = "List View Profile",
+    ) -> dict:
+        """Trigger the only show populated columns for the given cycle and column list profile name. If the column list profile name does not exist, then it will create a new one.
 
-    #     Args:
-    #         cycle_id (int): _description_
+        Args:
+            cycle_id (int): ID of the cycle to run the show only populated on
+            name (str): Name of the column list profile to create
+            inventory_type (str, optional): Property or Tax Lot. Defaults to "Property".
+            profile_location (str, optional): Detail View Profile or List View Profile. Defaults to "List View Profile".
 
-    #     Returns:
-    #         dict: _description_
-    #     """
-    #     # {"cycle_id": 13, "inventory_type": "Property"}
-    #     # column_list_profiles/1/show_populated/
-    #     return None
+        Returns:
+            dict: dict of the updated column list profile
+        """
+        # get the ID of the column_list_profile_name
+        column_list_profiles = self.get_column_list_profiles()
+        column_list_profile_id = None
+        for profile in column_list_profiles:
+            if profile["name"] == column_list_profile_name:
+                column_list_profile_id = profile["id"]
+                break
+
+        if not column_list_profile_id:
+            # create a default column list profile
+            column_list_profile = self.get_or_create_column_list_profile(column_list_profile_name, inventory_type, profile_location)
+            column_list_profile_id = column_list_profile["id"]
+
+        if not column_list_profile_id:
+            raise ValueError(f"Could not find column list profile with name {column_list_profile_name} to run show only populated")
+
+        # {"cycle_id": 13, "inventory_type": "Property"}
+        # column_list_profiles/PK/show_populated/
+        payload: dict[str, Any] = {
+            "cycle_id": cycle_id,
+            "inventory_type": inventory_type,
+        }
+        result = self.client.put(
+            None,
+            required_pk=False,
+            endpoint="column_list_profiles_pk_show_populated",
+            json=payload,
+            url_args={"PK": column_list_profile_id},
+        )
+        print(result)
+
+        return result
 
     def search_buildings(
         self,

--- a/pyseed/seed_client.py
+++ b/pyseed/seed_client.py
@@ -323,6 +323,10 @@ class SeedClient(SeedClientWrapper):
         Returns:
             list: list of dictionaries of each property, grouped by primary key (matching criteria)
         """
+        # coerce IDs into integers
+        column_list_profile_id = int(column_list_profile_id)
+        cycle_ids = [int(cycle_id) for cycle_id in cycle_ids]
+
         payload = {"profile_id": column_list_profile_id, "cycle_ids": cycle_ids}
         return self.client.post(endpoint="properties_filter_by_cycle", json=payload)
 

--- a/pyseed/seed_client_base.py
+++ b/pyseed/seed_client_base.py
@@ -424,7 +424,6 @@ class CreateMixin:
             url = url + "/"
         url = _replace_url_args(url, url_args)
         response = super()._post(url=url, **kwargs)
-        print(response.json())
         self._check_response(response, **kwargs)
         return self._get_result(response, data_name=data_name, **kwargs)
 

--- a/pyseed/seed_client_base.py
+++ b/pyseed/seed_client_base.py
@@ -66,6 +66,7 @@ URLS = {
         "org_column_mapping_import_file": "api/v3/organizations/ORG_ID/column_mappings/",
         "portfolio_manager_property_download": "/api/v3/portfolio_manager/PK/download/",
         # PUTs with replaceable keys:
+        "column_list_profiles_pk_show_populated": "/api/v3/column_list_profiles/PK/show_populated/",
         "properties_update_with_buildingsync": "api/v3/properties/PK/update_with_building_sync/",
         "properties_upload_inventory_document": "api/v3/properties/PK/upload_inventory_document",
         "property_update_with_espm": "api/v3/properties/PK/update_with_espm/",

--- a/pyseed/seed_client_base.py
+++ b/pyseed/seed_client_base.py
@@ -30,6 +30,7 @@ from pyseed.exceptions import SEEDError
 # Constants (Should end with a slash)
 URLS = {
     "v3": {
+        "column_list_profiles": "/api/v3/column_list_profiles/",
         "column_mapping_profiles": "/api/v3/column_mapping_profiles/",
         "column_mapping_profiles_filter": "/api/v3/column_mapping_profiles/filter/",
         "columns": "/api/v3/columns/",
@@ -50,6 +51,7 @@ URLS = {
         "properties": "/api/v3/properties/",
         "properties_labels": "/api/v3/properties/labels/",
         "properties_search": "/api/v3/properties/search/",
+        "properties_filter_by_cycle": "/api/v3/properties/filter_by_cycle/",
         "property_views": "/api/v3/property_views/",
         "taxlots": "/api/v3/taxlots/",
         "upload": "/api/v3/upload/",
@@ -79,6 +81,8 @@ URLS = {
         "properties_meters": "/api/v3/properties/PK/meters/",
         # GET & POST with replaceable keys
         "properties_meters_reading": "/api/v3/properties/PK/meters/METER_PK/readings/",
+        # DELETES with replaceable keys
+        "delete_inventory": "api/v3/organizations/ORG_ID/inventory/",
     },
 }
 
@@ -241,7 +245,7 @@ class SEEDBaseClient(JSONAPI):
                     # For the delete cycles, the data returned have a status and a progress_key,
                     # but no progress_data. In lieu of updating SEED, this check is added
                     # specifically for this case
-                    error = status_field not in ["not-started", "success", "parsing"]
+                    error = status_field not in ["not-started", "success", "parsing", "running"]
                 elif status_field == "error":
                     error = True
                 elif status_field == "success":
@@ -255,18 +259,32 @@ class SEEDBaseClient(JSONAPI):
                 # this is a system matching response, which is okay. return the success flag of this
                 status_flag = response.json()["progress_data"].get("status", None)
                 error = status_flag not in ["not-started", "success", "parsing"]
-            elif not any(
-                key in ["results", "readings", "data", "status", "id", "organizations", "sha", "users"] for key in response.json()
-            ):
-                # In some cases there is not a 'status' field, so check if there are
-                # any other keys in the response that depict a success:
-                # readings - this comes from meters
-                # data - lots of responses just return the data flag
-                # status - sometimes the status comes back as complete
-                # id - For some object creates, the response is simply the object back in JSON format with an ID field.
-                # organizations - this is the only key when returning the list of orgs
-                # sha - When parsing the version of SEED
-                error = True
+            # check if the first element is a list and the key is a castable ID
+            elif len(response.json()) > 0:
+                error_state = True
+                # get the first key -- based on ruff, this is the way to do it.
+                first_key = next(iter(response.json().keys()))
+                # if the first
+                if first_key in ["results", "readings", "data", "status", "id", "organizations", "sha", "users"]:
+                    # In some cases there is not a 'status' field, so check if there are
+                    # any other keys in the response that depict a success:
+                    # readings - this comes from meters
+                    # data - lots of responses just return the data flag
+                    # status - sometimes the status comes back as complete
+                    # id - For some object creates, the response is simply the object back in JSON format with an ID field.
+                    # organizations - this is the only key when returning the list of orgs
+                    # sha - When parsing the version of SEED
+                    error_state = False
+                else:
+                    # In the cross cycle readings, the data are returned as a dict of lists, where the key should be cycle ID
+                    try:
+                        int(first_key)
+                    except ValueError:
+                        error_state = True
+
+                    error_state = False
+
+                error = error_state
 
         elif not isinstance(response.json(), list):
             error = True
@@ -405,6 +423,7 @@ class CreateMixin:
             url = url + "/"
         url = _replace_url_args(url, url_args)
         response = super()._post(url=url, **kwargs)
+        print(response.json())
         self._check_response(response, **kwargs)
         return self._get_result(response, data_name=data_name, **kwargs)
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,10 +1,10 @@
 -r requirements.txt
-mock==5.1.0
-mypy==1.11.2
-pre-commit==3.8.0
-pytest==8.2.2
-pytest-cov==5.0.0
-pytest-order==1.2.1
+mock==5.2.0
+mypy==1.15.0
+pre-commit==4.2.0
+pytest==8.3.5
+pytest-cov==6.0.0
+pytest-order==1.3.0
 pytest-xdist==3.6.1
 testfixtures>=8.3.0
-tox==4.21.0
+tox==4.24.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-openpyxl==3.1.2
+openpyxl==3.1.5
 requests>=2.28.0

--- a/tests/test_seed_base.py
+++ b/tests/test_seed_base.py
@@ -12,21 +12,23 @@ import pytest
 
 from pyseed.seed_client import SeedClient
 
+# This is a default org ID, which will be overridden in the tests.
+# It really isn't used anymore, but keeping here for now.
+ORGANIZATION_ID = 1
+
 
 @pytest.mark.integration
 class SeedBaseTest(unittest.TestCase):
     @classmethod
     def setup_class(cls):
         """setup for all of the tests below"""
-        cls.organization_id = 1
-
         # The seed-config.json file needs to be added to the project root directory
         # If running SEED locally for testing, then you can run the following from your SEED root directory:
         #    ./manage.py create_test_user_json --username user@seed-platform.org --file ../py-seed/seed-config.json --pyseed
         config_file = Path("seed-config.json")
-        cls.seed_client = SeedClient(cls.organization_id, connection_config_filepath=config_file)
-
-        cls.organization_id = 1
+        cls.seed_client = SeedClient(ORGANIZATION_ID, connection_config_filepath=config_file)
+        new_org = cls.seed_client.create_organization("pyseed-base-tests", allow_exist=True)
+        cls.seed_client.client.org_id = new_org["organization"]["id"]
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_seed_client.py
+++ b/tests/test_seed_client.py
@@ -492,6 +492,7 @@ class SeedClientColumnListProfileTest(unittest.TestCase):
         # need to be updated to handle deleting data from multiple orgs if the tests are across
         # multiple orgs.
         cls.seed_client.delete_inventory()
+        # pass
 
     def test_create_column_list_profiles(self):
         # Get/create the new cycle and upload the data. Make sure to set the cycle ID so that the
@@ -549,6 +550,66 @@ class SeedClientColumnListProfileTest(unittest.TestCase):
         # call the method to create a column list profile based on populated fields
         result = self.seed_client.get_or_create_column_list_profile(column_list_profile_name, "Property", "List View Profile")
         assert result["name"] == column_list_profile_name
+
+    def test_trigger_only_populated_columns(self):
+        new_org = self.seed_client.create_organization("pyseed-column-list-tests", allow_exist=True)
+        self.seed_client.client.org_id = new_org["organization"]["id"]
+
+        # create a single building
+        cycle = self.seed_client.get_or_create_cycle(
+            "pyseed-api-integration-test",
+            date(2025, 1, 1),
+            date(2025, 12, 31),
+            set_cycle_id=True,
+        )
+
+        state = {
+            "organization_id": self.seed_client.client.org_id,
+            "custom_id_1": "23456",
+            "address_line_1": "234 Ambling Road",
+            "city": "Beverly Hills",
+            "state": "CA",
+            "postal_code": "90210",
+            "property_name": "Test Building",
+            "property_type": None,
+            "gross_floor_area": None,
+            "conditioned_floor_area": None,
+            "occupied_floor_area": None,
+            "site_eui": None,
+            "site_eui_modeled": None,
+            "source_eui_weather_normalized": None,
+            "source_eui": None,
+            "source_eui_modeled": None,
+            "site_eui_weather_normalized": None,
+            "total_ghg_emissions": None,
+            "total_marginal_ghg_emissions": None,
+            "total_ghg_emissions_intensity": None,
+            "total_marginal_ghg_emissions_intensity": None,
+            "generation_date": None,
+            "recent_sale_date": None,
+            "release_date": None,
+        }
+
+        params = {"state": state, "cycle_id": cycle["id"]}
+
+        result = self.seed_client.create_building(params=params)
+        assert result["status"] == "success"
+        assert result["view"]["id"] is not None
+
+        # get all the column lists -- should be none
+        column_list_profile_name = "Test Profile"
+
+        # if the column list is empty, then create a new one that will be used
+        # with the only show populated
+        result = self.seed_client.get_or_create_column_list_profile(column_list_profile_name, "Property", "List View Profile")
+        assert result["name"] == column_list_profile_name
+
+        # call the method to create a column list profile based on populated fields
+        result = self.seed_client.trigger_show_only_populated(cycle["id"], column_list_profile_name, "Property", "List View Profile")
+        assert result["name"] == column_list_profile_name
+
+        # check that there are only 8 columns now, based on the data above (6 field [org not show] + created + updated)
+        assert len(result["columns"]) == 8
 
 
 @pytest.mark.integration

--- a/tests/test_seed_client.py
+++ b/tests/test_seed_client.py
@@ -12,7 +12,8 @@ import pytest
 
 from pyseed.seed_client import SeedClient
 
-# For CI the test org is 1, but for local testing it may be different
+# This is a default org ID, which will be overridden in the tests.
+# It really isn't used anymore, but keeping here for now.
 ORGANIZATION_ID = 1
 
 
@@ -25,13 +26,14 @@ class SeedClientTest(unittest.TestCase):
         if not cls.output_dir.exists():
             cls.output_dir.mkdir()
 
-        cls.organization_id = ORGANIZATION_ID
-
         # The seed-config.json file needs to be added to the project root directory
         # If running SEED locally for testing, then you can run the following from your SEED root directory:
         #    ./manage.py create_test_user_json --username user@seed-platform.org --file ../py-seed/seed-config.json --pyseed
         config_file = Path("seed-config.json")
-        cls.seed_client = SeedClient(cls.organization_id, connection_config_filepath=config_file)
+        cls.seed_client = SeedClient(ORGANIZATION_ID, connection_config_filepath=config_file)
+
+        new_org = cls.seed_client.create_organization("pyseed-tests", allow_exist=True)
+        cls.seed_client.client.org_id = new_org["organization"]["id"]
 
         # Get/create the new cycle and upload the data. Make sure to set the cycle ID so that the
         # data end up in the correct cycle
@@ -76,8 +78,8 @@ class SeedClientTest(unittest.TestCase):
         assert len(buildings) == 10
 
     def test_get_pm_report_template_names(self):
-        pm_un = os.environ.get("SEED_PM_UN", False)
-        pm_pw = os.environ.get("SEED_PM_PW", False)
+        pm_un = os.environ.get("SEED_PM_UN", None)
+        pm_pw = os.environ.get("SEED_PM_PW", None)
         if not pm_un or not pm_pw:
             self.fail(f"Somehow PM test was initiated without {pm_un} or {pm_pw} in the environment")
         response = self.seed_client.get_pm_report_template_names(pm_un, pm_pw)
@@ -126,7 +128,7 @@ class SeedClientTest(unittest.TestCase):
         )
 
         state = {
-            "organization_id": self.organization_id,
+            "organization_id": self.seed_client.client.org_id,
             "custom_id_1": "123456",
             "address_line_1": "123 Testing St",
             "city": "Beverly Hills",
@@ -396,6 +398,160 @@ class SeedClientTest(unittest.TestCase):
 
 
 @pytest.mark.integration
+class SeedClientDeleteTest(unittest.TestCase):
+    @classmethod
+    def setup_class(cls):
+        """setup for all of the tests below"""
+        cls.output_dir = Path("tests/output")
+        if not cls.output_dir.exists():
+            cls.output_dir.mkdir()
+
+        # The seed-config.json file needs to be added to the project root directory
+        # If running SEED locally for testing, then you can run the following from your SEED root directory:
+        #    ./manage.py create_test_user_json --username user@seed-platform.org --file ../py-seed/seed-config.json --pyseed
+        config_file = Path("seed-config.json")
+        cls.seed_client = SeedClient(ORGANIZATION_ID, connection_config_filepath=config_file)
+
+    def test_delete_inventory(self):
+        # Get/create the new cycle and upload the data. Make sure to set the cycle ID so that the
+        # data end up in the correct cycle
+        new_org = self.seed_client.create_organization("pyseed-delete-tests", allow_exist=True)
+        self.seed_client.client.org_id = new_org["organization"]["id"]
+
+        # create a single building
+        cycle = self.seed_client.get_or_create_cycle(
+            "pyseed-api-integration-test",
+            date(2025, 1, 1),
+            date(2025, 12, 31),
+            set_cycle_id=True,
+        )
+
+        state = {
+            "organization_id": self.seed_client.client.org_id,
+            "custom_id_1": "123456",
+            "address_line_1": "123 Testing St",
+            "city": "Beverly Hills",
+            "state": "CA",
+            "postal_code": "90210",
+            "property_name": "Test Building",
+            "property_type": None,
+            "gross_floor_area": None,
+            "conditioned_floor_area": None,
+            "occupied_floor_area": None,
+            "site_eui": None,
+            "site_eui_modeled": None,
+            "source_eui_weather_normalized": None,
+            "source_eui": None,
+            "source_eui_modeled": None,
+            "site_eui_weather_normalized": None,
+            "total_ghg_emissions": None,
+            "total_marginal_ghg_emissions": None,
+            "total_ghg_emissions_intensity": None,
+            "total_marginal_ghg_emissions_intensity": None,
+            "generation_date": None,
+            "recent_sale_date": None,
+            "release_date": None,
+        }
+
+        params = {"state": state, "cycle_id": cycle["id"]}
+
+        result = self.seed_client.create_building(params=params)
+        assert result["status"] == "success"
+        assert result["view"]["id"] is not None
+
+        # verify that there is a single building in the inventory
+        properties = self.seed_client.get_buildings()
+        assert len(properties) == 1
+
+        # test deleting all the inventory
+        self.seed_client.delete_inventory()
+
+        # verify that there are no buildings in the inventory
+        properties = self.seed_client.get_buildings()
+        assert len(properties) == 0
+
+
+@pytest.mark.integration
+class SeedClientColumnListProfileTest(unittest.TestCase):
+    @classmethod
+    def setup_class(cls):
+        """setup for all of the tests below"""
+        cls.output_dir = Path("tests/output")
+        if not cls.output_dir.exists():
+            cls.output_dir.mkdir()
+
+        # The seed-config.json file needs to be added to the project root directory
+        # If running SEED locally for testing, then you can run the following from your SEED root directory:
+        #    ./manage.py create_test_user_json --username user@seed-platform.org --file ../py-seed/seed-config.json --pyseed
+        config_file = Path("seed-config.json")
+        cls.seed_client = SeedClient(ORGANIZATION_ID, connection_config_filepath=config_file)
+
+    @classmethod
+    def teardown_class(cls):
+        # remove all the inventory (buildings and taxlots) from the set organization. This might
+        # need to be updated to handle deleting data from multiple orgs if the tests are across
+        # multiple orgs.
+        cls.seed_client.delete_inventory()
+
+    def test_create_column_list_profiles(self):
+        # Get/create the new cycle and upload the data. Make sure to set the cycle ID so that the
+        # data end up in the correct cycle
+        new_org = self.seed_client.create_organization("pyseed-column-list-tests", allow_exist=True)
+        self.seed_client.client.org_id = new_org["organization"]["id"]
+
+        # create a single building
+        cycle = self.seed_client.get_or_create_cycle(
+            "pyseed-api-integration-test",
+            date(2025, 1, 1),
+            date(2025, 12, 31),
+            set_cycle_id=True,
+        )
+
+        state = {
+            "organization_id": self.seed_client.client.org_id,
+            "custom_id_1": "123456",
+            "address_line_1": "123 Testing St",
+            "city": "Beverly Hills",
+            "state": "CA",
+            "postal_code": "90210",
+            "property_name": "Test Building",
+            "property_type": None,
+            "gross_floor_area": None,
+            "conditioned_floor_area": None,
+            "occupied_floor_area": None,
+            "site_eui": None,
+            "site_eui_modeled": None,
+            "source_eui_weather_normalized": None,
+            "source_eui": None,
+            "source_eui_modeled": None,
+            "site_eui_weather_normalized": None,
+            "total_ghg_emissions": None,
+            "total_marginal_ghg_emissions": None,
+            "total_ghg_emissions_intensity": None,
+            "total_marginal_ghg_emissions_intensity": None,
+            "generation_date": None,
+            "recent_sale_date": None,
+            "release_date": None,
+        }
+
+        params = {"state": state, "cycle_id": cycle["id"]}
+
+        result = self.seed_client.create_building(params=params)
+        assert result["status"] == "success"
+        assert result["view"]["id"] is not None
+
+        # get all the column lists -- should be none
+        column_list_profile_name = "Test Profile"
+        column_list_profiles = self.seed_client.get_column_list_profiles()
+        # this might return nothing, so just check if it is a list
+        assert isinstance(column_list_profiles, list)
+
+        # call the method to create a column list profile based on populated fields
+        result = self.seed_client.get_or_create_column_list_profile(column_list_profile_name, "Property", "List View Profile")
+        assert result["name"] == column_list_profile_name
+
+
+@pytest.mark.integration
 class SeedClientMultiCycleTest(unittest.TestCase):
     @classmethod
     def setup_class(cls):
@@ -404,25 +560,20 @@ class SeedClientMultiCycleTest(unittest.TestCase):
         if not cls.output_dir.exists():
             cls.output_dir.mkdir()
 
-        # Use the default organization to create the client,
-        # but this will be overwritten in the test class below.
-        cls.organization_id = ORGANIZATION_ID
-
         # The seed-config.json file needs to be added to the project root directory
         # If running SEED locally for testing, then you can run the following from your SEED root directory:
         #    ./manage.py create_test_user_json --username user@seed-platform.org --file ../py-seed/seed-config.json --pyseed
         config_file = Path("seed-config.json")
-        cls.seed_client = SeedClient(cls.organization_id, connection_config_filepath=config_file)
+        cls.seed_client = SeedClient(ORGANIZATION_ID, connection_config_filepath=config_file)
 
     @classmethod
     def teardown_class(cls):
-        # remove all of the test buildings?
-        pass
+        cls.seed_client.delete_inventory()
 
     def test_upload_multiple_cycles_and_read_back(self):
         # Get/create the new cycle and upload the data. Make sure to set the cycle ID so that the
         # data end up in the correct cycle
-        new_org = self.seed_client.create_organization("pyseed-multi-cycle")
+        new_org = self.seed_client.create_organization("pyseed-multi-cycle", allow_exist=True)
         self.seed_client.client.org_id = new_org["organization"]["id"]
 
         for year_start, year_end in [(2020, 2021), (2021, 2022), (2022, 2023)]:
@@ -451,7 +602,7 @@ class SeedClientMultiCycleTest(unittest.TestCase):
         assert len(building) == 1
         property_view_id = building[0]["id"]
 
-        # retrieve cross cycle
+        # retrieve cross cycle data for a single building
         building_cycles = self.seed_client.get_cross_cycle_data(property_view_id)
 
         assert len(building_cycles) == 3


### PR DESCRIPTION
This PR adds support for pulling cross cycle inventory data. To do this, several other APIs needed to be exposed.

* Update dependency versions
* Update pre-commit versions
* Allow `create_organizations` to return an existing org, if passed
* Add `get_properties_by_cycle`. This is the cross cycle result
* Add `get_column_list_profiles` to return all of the profiles. The value needs to be passed to `get_properties_by_cycle`.
* Add `delete_inventory` -- use with CAUTION!
* Add `trigger only show populate columns` on a column list profile